### PR TITLE
Add type definition for stops

### DIFF
--- a/tinygradient.d.ts
+++ b/tinygradient.d.ts
@@ -12,13 +12,13 @@ declare namespace tinygradient {
 
     type CssMode = 'linear' | 'radial';
 
-    interface Stop {
-        color: tinycolor.Instance
+    type StopInput = {
+        color: tinycolor.ColorInput
         pos: number
     }
 
     interface Instance {
-        stops: Stop[]
+        stops: StopInput[]
 
         /**
          * Return new instance with reversed stops
@@ -74,10 +74,10 @@ declare namespace tinygradient {
          * @class tinygradient
          * @param {tinycolor.ColorInput[]} stops
          */
-        new (stops: tinycolor.ColorInput[]): Instance;
-        new (...stops: tinycolor.ColorInput[]): Instance;
-        (stops: tinycolor.ColorInput[]): Instance;
-        (...stops: tinycolor.ColorInput[]): Instance;
+        new (stops: StopInput[] | tinycolor.ColorInput[]): Instance;
+        new (...stops: StopInput[] | tinycolor.ColorInput[]): Instance;
+        (stops: StopInput[] | tinycolor.ColorInput[]): Instance;
+        (...stops: StopInput[] | tinycolor.ColorInput[]): Instance;
 
         /**
          * Generate gradient with RGBa interpolation
@@ -85,7 +85,7 @@ declare namespace tinygradient {
          * @param {int} steps
          * @return {tinycolor.Instance[]}
          */
-        rgb(stops: tinycolor.ColorInput[], steps: number): tinycolor.Instance[];
+        rgb(stops: StopInput[] | tinycolor.ColorInput[], steps: number): tinycolor.Instance[];
 
         /**
          * Generate gradient with HSVa interpolation
@@ -98,7 +98,7 @@ declare namespace tinygradient {
          *    - 'long' to use the longest way
          * @return {tinycolor.Instance[]}
          */
-        hsv(stops: tinycolor.ColorInput[], steps: number, mode: ArcMode): tinycolor.Instance[];
+        hsv(stops: StopInput[] | tinycolor.ColorInput[], steps: number, mode: ArcMode): tinycolor.Instance[];
 
         /**
          * Generate CSS3 command (no prefix) for this gradient
@@ -107,7 +107,7 @@ declare namespace tinygradient {
          * @param {String} [direction] - default is 'to right' or 'ellipse at center'
          * @return {String}
          */
-        css(stops: tinycolor.ColorInput[], mode?: CssMode, direction?: string): string;
+        css(stops: StopInput[] | tinycolor.ColorInput[], mode?: CssMode, direction?: string): string;
 
         /**
          * Returns the color at specific position with RGBa interpolation
@@ -115,7 +115,7 @@ declare namespace tinygradient {
          * @param {float} pos, between 0 and 1
          * @return {tinycolor.Instance}
          */
-        rgbAt(stops: tinycolor.ColorInput[], pos: number): tinycolor.Instance;
+        rgbAt(stops: StopInput[] | tinycolor.ColorInput[], pos: number): tinycolor.Instance;
 
         /**
          * Returns the color at specific position with HSVa interpolation
@@ -123,7 +123,7 @@ declare namespace tinygradient {
          * @param {float} pos, between 0 and 1
          * @return {tinycolor.Instance}
          */
-        hsvAt(stops: tinycolor.ColorInput[], pos: number): tinycolor.Instance;
+        hsvAt(stops: StopInput[] | tinycolor.ColorInput[], pos: number): tinycolor.Instance;
     }
 }
 

--- a/tinygradient.d.ts
+++ b/tinygradient.d.ts
@@ -12,7 +12,13 @@ declare namespace tinygradient {
 
     type CssMode = 'linear' | 'radial';
 
+    interface Stop {
+        color: tinycolor.Instance
+        pos: number
+    }
+
     interface Instance {
+        stops: Stop[]
 
         /**
          * Return new instance with reversed stops


### PR DESCRIPTION
I have a use case where I'd like to use a tinygradient as a lookup for the stops that were used to create the instance.

I already noticed that `stops` were being assigned in the constructor, but weren't exposed in the type definition.