### PR TITLE
Preventing Error TS2370

### DIFF
--- a/tinygradient.d.ts
+++ b/tinygradient.d.ts
@@ -74,10 +74,14 @@ declare namespace tinygradient {
          * @class tinygradient
          * @param {tinycolor.ColorInput[]} stops
          */
-        new (stops: (StopInput | tinycolor.ColorInput)[]): Instance;
-        new (...stops: (StopInput | tinycolor.ColorInput)[]): Instance;
-        (stops: (StopInput | tinycolor.ColorInput)[]): Instance;
-        (...stops: (StopInput | tinycolor.ColorInput)[]): Instance;
+        new (stops: StopInput[]): Instance;
+        new (...stops: StopInput[]): Instance;
+        (stops: StopInput[]): Instance;
+        (...stops: StopInput[]): Instance;
+        new (stops: tinycolor.ColorInput[]): Instance;
+        new (...stops: tinycolor.ColorInput[]): Instance;
+        (stops: tinycolor.ColorInput[]): Instance;
+        (...stops: tinycolor.ColorInput[]): Instance;
 
         /**
          * Generate gradient with RGBa interpolation

--- a/tinygradient.d.ts
+++ b/tinygradient.d.ts
@@ -74,10 +74,10 @@ declare namespace tinygradient {
          * @class tinygradient
          * @param {tinycolor.ColorInput[]} stops
          */
-        new (stops: StopInput[] | tinycolor.ColorInput[]): Instance;
-        new (...stops: StopInput[] | tinycolor.ColorInput[]): Instance;
-        (stops: StopInput[] | tinycolor.ColorInput[]): Instance;
-        (...stops: StopInput[] | tinycolor.ColorInput[]): Instance;
+        new (stops: (StopInput | tinycolor.ColorInput)[]): Instance;
+        new (...stops: (StopInput | tinycolor.ColorInput)[]): Instance;
+        (stops: (StopInput | tinycolor.ColorInput)[]): Instance;
+        (...stops: (StopInput | tinycolor.ColorInput)[]): Instance;
 
         /**
          * Generate gradient with RGBa interpolation


### PR DESCRIPTION
TypeScript is complaining about being given two types for a rest parameter (`error TS2370: A rest parameter must be of an array type.`). A minor tweak to the structure of the type resolves this.