### PR TITLE
fix: Add back support for TypeScript

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -97,5 +97,5 @@ declare namespace tinygradient {
 }
 
 declare const tinygradient: tinygradient.Constructor;
-export = tinygradient;
-export as namespace tinygradient;
+export default tinygradient;
+export { tinygradient };


### PR DESCRIPTION
The commit aiming to move to ESM ([here](https://github.com/mistic100/tinygradient/commit/86a321e52bec76ff461439edff07bf9a0a202a7e)) seems to have broken typings.

If you run `npm i && npm run typecheck` on the following reproduction env ([here](https://stackblitz.com/edit/vitejs-vite-3nfrtdhx)) you'll see that the default import does not work anymore for TypeScript. Moving back the version to 1 makes it compile.

With version 2 it fails with the error:

```txt
src/main.ts:1:8 - error TS1192: Module '"/home/projects/vitejs-vite-3nfrtdhx/node_modules/tinygradient/types"' has no default export.

1 import tinygradient from 'tinygradient';
         ~~~~~~~~~~~~


Found 1 error in src/main.ts:1
```